### PR TITLE
ci: dependabot: request reviews from team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     reviewers:
-      - liamsi
       - tzdybal
+      - "celestiaorg/execution-environment"
     labels:
       - T:dependencies


### PR DESCRIPTION
Dependabot configuration is out of date. This PR requests reviews from Exec-Envs team (and me personally, because I would like to keep track of this).

<!-- 
Please provide an explanation of the PR, including the apprioprate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->