### PR TITLE
client: bump namespace size

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func (c *Client) SubmitTx(ctx context.Context, tx []byte) /* TxResponse */ error
 	return errors.New("method SubmitTx not implemented")
 }
 
-func (c *Client) SubmitPFB(ctx context.Context, namespaceID [8]byte, data []byte, fee int64, gasLimit uint64) (*TxResponse, error) {
+func (c *Client) SubmitPFB(ctx context.Context, namespaceID [28]byte, data []byte, fee int64, gasLimit uint64) (*TxResponse, error) {
 	req := SubmitPFBRequest{
 		NamespaceID: hex.EncodeToString(namespaceID[:]),
 		Data:        hex.EncodeToString(data),
@@ -68,7 +68,7 @@ func (c *Client) SubmitPFB(ctx context.Context, namespaceID [8]byte, data []byte
 	return &res, nil
 }
 
-func (c *Client) NamespacedShares(ctx context.Context, namespaceID [8]byte, height uint64) ([][]byte, error) {
+func (c *Client) NamespacedShares(ctx context.Context, namespaceID [28]byte, height uint64) ([][]byte, error) {
 	var res struct {
 		Shares [][]byte `json:"shares"`
 		Height uint64   `json:"height"`
@@ -82,7 +82,7 @@ func (c *Client) NamespacedShares(ctx context.Context, namespaceID [8]byte, heig
 	return res.Shares, nil
 }
 
-func (c *Client) NamespacedData(ctx context.Context, namespaceID [8]byte, height uint64) ([][]byte, error) {
+func (c *Client) NamespacedData(ctx context.Context, namespaceID [28]byte, height uint64) ([][]byte, error) {
 	var res struct {
 		Data   [][]byte `json:"data"`
 		Height uint64   `json:"height"`
@@ -97,7 +97,7 @@ func (c *Client) NamespacedData(ctx context.Context, namespaceID [8]byte, height
 }
 
 // callNamespacedEndpoint fetches result of /namespaced_{type} family of endpoints into result (this should be pointer!)
-func (c *Client) callNamespacedEndpoint(ctx context.Context, namespaceID [8]byte, height uint64, endpoint string, result interface{}) error {
+func (c *Client) callNamespacedEndpoint(ctx context.Context, namespaceID [28]byte, height uint64, endpoint string, result interface{}) error {
 	var rpcErr string
 	_, err := c.c.R().
 		SetContext(ctx).
@@ -117,6 +117,6 @@ func headerPath() string {
 	return fmt.Sprintf("%s/%s", headerEndpoint, heightKey)
 }
 
-func namespacedPath(endpoint string, namespaceID [8]byte, height uint64) string {
+func namespacedPath(endpoint string, namespaceID [28]byte, height uint64) string {
 	return fmt.Sprintf("%s/%s/height/%d", endpoint, hex.EncodeToString(namespaceID[:]), height)
 }

--- a/integration_test/cnc_test.go
+++ b/integration_test/cnc_test.go
@@ -76,13 +76,13 @@ func (i *IntegrationTestSuite) TestDataRoundTrip() {
 	i.NotNil(client)
 
 	randomData := []byte("random data")
-	txRes, err := client.SubmitPFB(context.TODO(), [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, randomData, 10000, 100000)
+	txRes, err := client.SubmitPFB(context.TODO(), [28]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8}, randomData, 10000, 100000)
 	i.Require().NoError(err)
 	i.Require().NotNil(txRes)
 	i.Assert().Zero(txRes.Code)
 	expectedHeight := txRes.Height
 
-	data, err := client.NamespacedData(context.TODO(), [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, uint64(expectedHeight))
+	data, err := client.NamespacedData(context.TODO(), [28]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8}, uint64(expectedHeight))
 	i.Require().NoError(err)
 	i.Require().NotNil(data)
 	i.Len(data, 1)


### PR DESCRIPTION

## Overview

This PR updates the namespace id size from 8 bytes to 28 bytes to make it compatible with latest celestia node v0.10.2.

-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
