### PR TITLE
client: fix submitpfb namespace hack

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,8 +46,7 @@ func (c *Client) SubmitTx(ctx context.Context, tx []byte) /* TxResponse */ error
 
 func (c *Client) SubmitPFB(ctx context.Context, namespace Namespace, data []byte, fee int64, gasLimit uint64) (*TxResponse, error) {
 	req := SubmitPFBRequest{
-		// FIXME: See https://github.com/celestiaorg/celestia-node/issues/2292
-		NamespaceID: hex.EncodeToString(namespace.Bytes()[1:]),
+		NamespaceID: hex.EncodeToString(namespace.Bytes()),
 		Data:        hex.EncodeToString(data),
 		Fee:         fee,
 		GasLimit:    gasLimit,


### PR DESCRIPTION
## Overview

This PR removes the namespace hack for `submit_pfb` request which was introduced in #56 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
