### PR TITLE
bridge: flags - add --gateway.deprecated-endpoints; fix submit pfb namespace hack

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,8 +46,7 @@ func (c *Client) SubmitTx(ctx context.Context, tx []byte) /* TxResponse */ error
 
 func (c *Client) SubmitPFB(ctx context.Context, namespace Namespace, data []byte, fee int64, gasLimit uint64) (*TxResponse, error) {
 	req := SubmitPFBRequest{
-		// FIXME: See https://github.com/celestiaorg/celestia-node/issues/2292
-		NamespaceID: hex.EncodeToString(namespace.Bytes()[1:]),
+		NamespaceID: hex.EncodeToString(namespace.Bytes()),
 		Data:        hex.EncodeToString(data),
 		Fee:         fee,
 		GasLimit:    gasLimit,

--- a/integration_test/docker/start-bridge.sh
+++ b/integration_test/docker/start-bridge.sh
@@ -13,6 +13,6 @@ echo  # newline
 export CELESTIA_CUSTOM=test:`cat genesis.hash`
 echo $CELESTIA_CUSTOM
 celestia bridge start \
-  --node.store /bridge --gateway \
+  --node.store /bridge --gateway --gateway.deprecated-endpoints \
   --core.ip 192.167.10.10 \
   --keyring.accname validator

--- a/integration_test/docker/test-docker-compose.yml
+++ b/integration_test/docker/test-docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   core0:
     container_name: core0
-    image: "ghcr.io/celestiaorg/celestia-app:v1.0.0-rc1"
+    image: "ghcr.io/celestiaorg/celestia-app:v1.0.0-rc5"
     user: root
     entrypoint: [
       "/bin/bash"
@@ -22,7 +22,7 @@ services:
     container_name: bridge0
     depends_on:
       - core0
-    image: "ghcr.io/celestiaorg/celestia-node:v0.11.0-rc1"
+    image: "ghcr.io/celestiaorg/celestia-node:v0.11.0-rc6"
     user: root
     entrypoint: [
       "/bin/bash"


### PR DESCRIPTION
## Overview

This PR adds `--gateway.deprecated-endpoints` flag to the bridge node.

While here, also fix the namespace hack around submit pfb endpoint.

## Checklist


- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
